### PR TITLE
- Turns out that low power decoder packs bytes in little endian order as per spec, w…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cptv-decoder"
+version = "0.1.0"
+dependencies = [
+ "codec",
+ "console_error_panic_hook",
+ "console_log",
+ "flate2",
+ "js-sys",
+ "log",
+ "nom",
+ "pollster",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "cptv-downloader"
 version = "0.1.0"
 
@@ -1434,25 +1453,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "wasm-bindings"
-version = "0.1.0"
-dependencies = [
- "codec",
- "console_error_panic_hook",
- "console_log",
- "flate2",
- "js-sys",
- "log",
- "nom",
- "pollster",
- "serde",
- "serde-wasm-bindgen",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "web-sys"

--- a/cptv-codec-rs/src/common/cptv_frame.rs
+++ b/cptv-codec-rs/src/common/cptv_frame.rs
@@ -99,8 +99,8 @@ fn unpack_frame_v2(
                 current_px += (delta as i16) as i32;
                 let prev_px = unsafe { *prev_frame.image_data.data.get_unchecked(index) } as i32;
 
-                assert!(prev_px + current_px <= u16::MAX as i32, "prev_px {}, current_px {}", prev_px, current_px);
-                assert!(prev_px + current_px >= 0, "prev_px {}, current_px {}", prev_px, current_px);
+                // assert!(prev_px + current_px <= u16::MAX as i32, "prev_px {}, current_px {}", prev_px, current_px);
+                // assert!(prev_px + current_px >= 0, "prev_px {}, current_px {}", prev_px, current_px);
                 let px = (prev_px + current_px) as u16;
                 *unsafe { image_data.data.get_unchecked_mut(index) } = px;
             }
@@ -112,8 +112,8 @@ fn unpack_frame_v2(
             {
                 current_px += (delta as i16) as i32;
                 let prev_px = unsafe { *prev_frame.image_data.data.get_unchecked(index) } as i32;
-                assert!(prev_px + current_px <= u16::MAX as i32, "prev_px {}, current_px {}", prev_px, current_px);
-                assert!(prev_px + current_px >= 0, "prev_px {}, current_px {}", prev_px, current_px);
+                // assert!(prev_px + current_px <= u16::MAX as i32, "prev_px {}, current_px {}", prev_px, current_px);
+                // assert!(prev_px + current_px >= 0, "prev_px {}, current_px {}", prev_px, current_px);
                 let px = (prev_px + current_px) as u16;
                 *unsafe { image_data.data.get_unchecked_mut(index) } = px;
             }

--- a/cptv-codec-rs/src/common/cptv_header.rs
+++ b/cptv-codec-rs/src/common/cptv_header.rs
@@ -1,7 +1,7 @@
 use crate::common::cptv_field_type::FieldType;
 use crate::common::{HEIGHT, WIDTH};
 use alloc::string::String;
-use core::fmt::{Debug, Formatter};
+use core::fmt::{Debug, Display, Formatter};
 use log::warn;
 use nom::bytes::streaming::{tag, take};
 use nom::character::streaming::char;
@@ -19,6 +19,12 @@ pub struct CptvString {
 impl Debug for CptvString {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "\"{}\"", self.inner)
+    }
+}
+
+impl Display for CptvString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "\"{:?}\"", self.inner)
     }
 }
 

--- a/cptv-codec-rs/src/decode/mod.rs
+++ b/cptv-codec-rs/src/decode/mod.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 pub use crate::common::cptv_frame::CptvFrame;
 pub use crate::common::cptv_header::CptvHeader;
 use crate::common::{HEIGHT, WIDTH};
+use crate::common::cptv_header::CptvString;
 
 struct DoubleBuffer {
     buffer_a: Vec<u8>,
@@ -169,15 +170,16 @@ impl<R: Read> CptvDecoder<R> {
     pub fn next_frame(&mut self) -> io::Result<&CptvFrame> {
         let header = self.get_header();
         if !header.is_ok() {
-            return Err(header.err().unwrap());
+            Err(header.err().unwrap())
         } else {
             // Get each frame.  The decoder will need to hold onto the previous frame in order
             // to decode the next.
             let mut buffer = [0u8; 1024]; // Read 1024 bytes at a time until we can decode the frame.
             let cptv_frame: CptvFrame;
+            let is_tc2 = header.expect("should have header").firmware_version.unwrap_or(CptvString::new()).as_string().contains("/");
             loop {
                 let initial_len = self.buffer.len();
-                match CptvFrame::from_bytes(&self.buffer, &self.prev_frame, &self.sequence) {
+                match CptvFrame::from_bytes(&self.buffer, &self.prev_frame, &self.sequence, is_tc2) {
                     Ok((remaining, frame)) => {
                         cptv_frame = frame;
                         self.prev_frame = Some(cptv_frame);

--- a/cptv-codec-rs/src/decode/mod.rs
+++ b/cptv-codec-rs/src/decode/mod.rs
@@ -256,7 +256,7 @@ impl<R: Read> CptvDecoder<R> {
                     self.buffer.extend_from_slice(&buffer[0..bytes_read]);
                     Ok(())
                 } else {
-                    return Err(Error::new(ErrorKind::Other, "Reached end of input"));
+                    Err(Error::new(ErrorKind::Other, "Reached end of input"))
                 }
             }
             Err(e) => {
@@ -265,7 +265,7 @@ impl<R: Read> CptvDecoder<R> {
                         // Let the loop continue and retry
                         Ok(())
                     }
-                    _ => return Err(e),
+                    _ => Err(e),
                 }
             }
         }

--- a/cptv-codec-rs/src/lib.rs
+++ b/cptv-codec-rs/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
+extern crate core;
 
 pub mod common;
 pub mod decode;

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -8,7 +8,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "python-cptv"
-version = "0.0.4"
+version = "0.0.6"
 authors = [
   { name="Jon Hardie", email="Jon@cacophony.org.nz" },
   { name = "Giampaolo Feraro", email = "Giampaolo@Cacophony.org.nz"}

--- a/wasm-bindings/Cargo.toml
+++ b/wasm-bindings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasm-bindings"
+name = "cptv-decoder"
 version = "0.1.0"
 edition = "2021"
 

--- a/wasm-bindings/build.sh
+++ b/wasm-bindings/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-wasm-pack build . --target nodejs
+wasm-pack build . --target web

--- a/wasm-bindings/src/lib.rs
+++ b/wasm-bindings/src/lib.rs
@@ -39,7 +39,7 @@ impl WebReader {
                         return Ok(bytes_read as usize);
                     }
                 }
-                return Ok(0);
+                Ok(0)
             }
             Err(_e) => Err(io::Error::new(ErrorKind::UnexpectedEof, "Stream error")),
         }


### PR DESCRIPTION
…hile python-cptv uses big endian, so work around the discrepancy by detecting what kind of file we're dealing with.  Unfortunately since we have a lot of files now created we can't reconcile this properly ever...

Anyway, this version of the decoder should resolve both file variants correctly.